### PR TITLE
rebuild for 3.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<39]
   # No need to set special variables for the DLL library path, as current version of the package will already look for the
   # dynamic library in conda path when using conda: https://github.com/Toblerity/rtree/blob/1.4.1/rtree/finder.py#L39

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -123,9 +123,6 @@ def boxes15_stream(interleaved=True):
         else:
             yield (i, (minx, maxx, miny, maxy), 42)
 
-def check_c_api():
-    assert int(str(index.__c_api_version__).split('.')[1]) >= 7
-
 def test_non_stream_input():
     p = index.Property()
     idx = index.Index(properties=p)
@@ -156,7 +153,6 @@ def test_property():
     assert p.handle is not unpickled.handle
     assert p.as_dict() == unpickled.as_dict()
 
-check_c_api()
 test_non_stream_input()
 
 test_stream_input()


### PR DESCRIPTION
rebuild for 3.14

Removed one test. index.__c_api_version__ gives 2.1.0 which matches the version of libspatialindex